### PR TITLE
Fix HTTPS warnings in modern browsers

### DIFF
--- a/_includes/script_head.html
+++ b/_includes/script_head.html
@@ -11,7 +11,7 @@
     ================================================== -->
 <link rel="stylesheet" type="text/css" href="/assets/css/style.css" media="screen">
 <link rel="stylesheet" type="text/css" href="/assets/css/prettyPhoto.css">
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,800,600,300' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700,800,600,300' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/jquery.slick/1.6.0/slick-theme.css">
 <link rel="alternate" type="application/rss+xml" href="http://blog.hsbne.org/rss">


### PR DESCRIPTION
Using http on any resource, in this case a font, breaks https support on most newer browsers (some will start flagging the site insecure soon)