### PR TITLE
Remove Stations Policy

### DIFF
--- a/admin/policy.md
+++ b/admin/policy.md
@@ -19,7 +19,6 @@ As soon as practical, once a member is on site they must swipe their access card
 
 ## Work For Membership
 
-
 The membership of HSBNE [ has decided ](/admin/meeting/20130521.html) that it wishes to offer membership in exchange for work. This is aimed at allowing less financially able people to continue to participate at HSBNE. The rules for this system, known as WOOFing, are as such:
 
  - There will be a cap of WOOFing members at 10% current membership.
@@ -33,31 +32,6 @@ The membership of HSBNE [ has decided ](/admin/meeting/20130521.html) that it wi
 Lifetime Members are members of HSBNE who have either accrued 10 years of membership or paid up in advance to accrue 10 years of membership. Lifetime Members do not have to pay for membership to maintain their voting/access rights. Paying in advance is calculated as 
 
     ( ( 10 * 12 ) - <accrued membership in months> ) * 55
-
-## Stations
-
-HSBNE encourages members to document in-house systems and processes such that they are repeatable, thorough, and usable. To this end, we have the Stations program. The Stations program gives members the opportunity to create a usable piece of infrastructure and be reimbursed by the group for their initiative. This means if you build tooling for the space and it's good enough that anyone can use it, HSBNE can vote to pay you for its building costs.
-
-A Station must have:
-
-- Usage clearly documented in a manner that anyone can follow without assistance
-- Ongoing costs documented
-- A member nominated as the maintainer
-
-Documentation for already existing stations are posted on the Wiki and physically at the station itself.
-
-It is reasonable to expect that if you use a station, and break something that is "expensive", and that can not be attributed to wear-and-tear, then you may be asked to fix it, or pay for it, or pay for part/most of it.
-
-All Stations have a "responsible person" who's job it is to ensure it remains usable, that consumables are upkept, that documentation is accurate, etc. This defaults to the person who "authored" it, untill they publish otherwise on the list and in the instructions.   The instructions *must* name this person, and their contact details ( eg phone & email ), so they can be notified in the case of issues, etc. 
-
-All changes to stations ( such as documentation, methodology, systems, etc ) must be "vetted" by the original "author" and/or the current "responsible person".
-
-Please don't break the documentation.   If you are designing a new/better way of doing something, the old system must continue to work until your revisions and documentation are "vetted" and accepted by the author, etc .
-
-If you want to create a new station, these are the steps you’ll need to follow:
-- Level 1 Documentation:  Project Proposal -  for "putting it to the group". This does not need firm "costings", but estimates will help your proposal. It is at this point that it is expected that someone unrelated should be able to follow your instructions without help to use the station.
-- Level 2 Documentation:  Grant Application - justifiable estimates of the costings, replacement costs, etc. and this is the point at which the ‘station’ must be voted on.
-- Level 3 Documentation:  This is the ongoing "living" document for periodic review.  Specifying actual cost/s incurred ( both upfront, and consumables ) and sources for replacement parts/consumeables. 
 
 ## Renting
 


### PR DESCRIPTION
This was never used. Might as well trim it away.

What it was intended to do we are now doing generally with regards to improved documentation for machines and processes.