### PR TITLE
Google account access sub policy

### DIFF
--- a/admin/access-gsuite.md
+++ b/admin/access-gsuite.md
@@ -1,0 +1,49 @@
+---
+title: Google HSBNE Account Access
+layout: default
+published: true
+---
+
+## Summary
+
+We give hsbne.org email addresses to volunteers.
+
+## Human Version
+
+* Google hsbne.org accounts are available to volunteers
+    * Team leads get them by default
+    * Volunteers can request them
+* They will be made in the format `firstname.lastname@hsbne.org`
+* Team members get added to the team google group and associated permissions
+* When a volunteer retires (becomes a normal member) the account may be closed.
+    * Closed accounts will have all their data merged to a shared location
+    * Theres no expectation of privacy
+* Legacy accounts from before this policy, we are aiming to reduce them.
+
+## Rules Version
+
+1. #### Account Creation
+
+    1. Google `@hsbne.org` accounts are available to volunteers
+    2. Team Leads get one by default
+    3. Volunteers can request them
+        1. It's preferred they use them over personal accounts
+    4. Accounts will be made in the format `firstname.lastname@hsbne.org`
+    5. Team members will be added to a team google group
+
+2. #### Account Deletion
+
+    1. On the retiring of a volunteer (becoming a normal member or non member)
+        1. Their account will be deleted
+        2. The data will be merged to a shared location for retention
+        3. There is no expectation of privacy of an account and it should be used for
+            HSBNE related activities only.
+
+3. #### Legacy Accounts
+
+    1. Accounts that exist prior to this policy and do not belong to volunteers are regarded as 'Legacy'
+    2. They will be located in the OU 'Legacy'
+    3. Where people stop their membership, it is preferred the account will be closed
+        1. Data will be merged if there is consent, otherwise deleted.
+    4. Executive has final discretion, but will aim to reduce the amount of Legacy accounts.
+

--- a/admin/access.md
+++ b/admin/access.md
@@ -20,6 +20,10 @@ Items can be added, removed, modified on the access register at any time by exec
 
 Some systems may have distinct levels of access which should be recorded as appropriate.
 
+### Sub Policy for specific resources:
+
+* [Google HSBNE Accounts](access-gsuite.html)
+
 ### Notification
 
 When a person is given access to a restricted resource they will be notified. When a person has restricted access removed, they will be notified which will include a reason for that removal. Notification may take any form, such as verbal or written.


### PR DESCRIPTION
Outlining some procedure around who gets hsbne.org accounts.

Mainly here so that its clear that once we close an account, it will be merged so we dont lose data. This is important before we start issuing a bunch of accounts to volunteers in teams.

Feedback welcome